### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/okrc/caddy-uploadcert-tencentcloud/security/code-scanning/1](https://github.com/okrc/caddy-uploadcert-tencentcloud/security/code-scanning/1)

To fix this problem, explicitly add a top-level `permissions` block to the workflow file. This block should restrict the `GITHUB_TOKEN` to having only the minimum privileges required, in this case, `contents: read`. Place this permissions block at the root of the file (before the `jobs:` key), so that it applies to all jobs in this workflow. No changes to steps or further job-level permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
